### PR TITLE
Install the cert-manager CRDs before the helm chart

### DIFF
--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -59,12 +59,12 @@ Install cert-manager and the CustomResourceDefinitions using one of the followin
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
 
+    # Install the CustomResourceDefinitions
+    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml
+
     # Install cert-manager into the cluster
     # Using helm3
     helm install cert-manager --namespace cert-manager --create-namespace --version v1.5.3 jetstack/cert-manager
-
-    # Install the CustomResourceDefinitions
-    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml
 
 Verify that the cert-manager pods have been created:
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change the order of the steps in Koperator install.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
You need to install the cert-manager CRDs first, before the helm chart, otherwise the helm chart install would fail with the following error:

```bash
$ k logs -n cert-manager cert-manager-startupapicheck-wsw74
Not ready: the cert-manager CRDs are not yet installed on the Kubernetes API server
...
Not ready: the cert-manager CRDs are not yet installed on the Kubernetes API server
Timed out after 1m0s
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)