### PR TITLE
Correcting producer flag (bootstrap-server is not a recognized option)

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -32,7 +32,7 @@ You can use the following commands to send and receive messages within a Kuberne
 - Produce messages:
 
     ```bash
-    kubectl -n kafka run kafka-producer -it --image=banzaicloud/kafka:2.13-2.4.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server kafka-headless:29092 --topic my-topic
+    kubectl -n kafka run kafka-producer -it --image=banzaicloud/kafka:2.13-2.4.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --broker-list kafka-headless:29092 --topic my-topic
     ```
 
     And type some test messages.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
A change in the producer flag for this test to work.


### Why?
The problem with current flag is that it breaks as it does not exist in that version:
```sh
$ kubectl -n kafka run kafka-producer -it --image=banzaicloud/kafka:2.13-2.4.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server kafka-headless:29092 --topic my-topic

If you don't see a command prompt, try pressing enter.
bootstrap-server is not a recognized option <-------------------------- Is not a recognized option!
```


### Additional context
But if proper flag is provided then we can work with it:
```sh
$ kubectl -n kafka run kafka-producer -it --image=banzaicloud/kafka:2.13-2.4.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --broker-list kafka-headless:29092 --topic my-topic
If you don't see a command prompt, try pressing enter.
>message1
>message2
>message3
>

```
Notice the only difference is in the flag: `--broker-list`


### Checklist

- [X ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X ] User guide and development docs updated (if needed)
