### PR TITLE
Update sasl oauth related doc to be in line with Kafka 3.1.0

### DIFF
--- a/docs/external-listener/index.md
+++ b/docs/external-listener/index.md
@@ -208,9 +208,14 @@ To connect to this listener using the Kafka console producer, complete the follo
 1. Set the producer properties like this:
 
     ```ini
-    sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub="producer";
     sasl.mechanism=OAUTHBEARER
     security.protocol=SASL_SSL
+    sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+    sasl.oauthbearer.token.endpoint.url=<https://myidp.example.com/oauth2/default/v1/token>
+    sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
+      clientId="<oauth-client-id>" \
+      clientSecret="<client-secret>" \
+      scope="kafka:write";
     ssl.truststore.location=/ssl/trustore.jks
     ssl.truststore.password=truststorepass
     ssl.endpoint.identification.algorithm=
@@ -230,9 +235,14 @@ To consume messages from this listener using the Kafka console consumer, complet
     group.id=consumer-1
     group.instance.id=consumer-1-instance-1
     client.id=consumer-1-instance-1
-    sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub="consumer";
     sasl.mechanism=OAUTHBEARER
-    security.protocol=SASL_SSL
+    security.protocol=SASL_SASL
+    sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+    sasl.oauthbearer.token.endpoint.url=<https://myidp.example.com/oauth2/default/v1/token>
+    sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
+      clientId="<oauth-client-id>" \
+      clientSecret="<client-secret>" \
+      scope="kafka:read" ;
     ssl.endpoint.identification.algorithm=
     ssl.truststore.location=/ssl/trustore.jks
     ssl.truststore.password=trustorepass


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no

| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update the sasl oauth part to reflect Kafka 3.1.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In kafka 3.1.0 the 
