### PR TITLE
docs(install): upped k8s range to 1.20+ (calisti)

### DIFF
--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -6,7 +6,7 @@ weight: 10
 
 
 
-The operator installs version 3.1.0 of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.19.0+.
+The operator installs version 3.1.0 of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.20.0+.
 
 > The operator supports Kafka 2.6.2-3.1.x.
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Upped the supported K8s range to 1.20+.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because we added K8s 1.22 support and dropping 1.19 support for now.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~[-] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- [X] User guide and development docs updated (if needed)
- ~[-] Related Helm chart(s) updated (if needed)~
