### PR TITLE
Add warning for installing koeprator in EKS with 1.23+

### DIFF
--- a/docs/headless/warning-ebs-csi-driver.md
+++ b/docs/headless/warning-ebs-csi-driver.md
@@ -1,0 +1,3 @@
+---
+---
+{{< warning >}}The ZooKeeper and the Kafka clusters need [persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to store data. Therefore, when installing the operator on Amazon EKS with Kubernetes version 1.23 or later, you [must install the EBS CSI driver add-on](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) on your cluster. {{< /warning >}}

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -10,7 +10,7 @@ The operator installs version 3.1.0 of Apache Kafka, and can run on Minikube v0.
 
 > The operator supports Kafka 2.6.2-3.1.x.
 
-{{< include "warning-ebs-csi-driver.md" "supertubes/kafka-operator" >}}
+{{< include-headless "warning-ebs-csi-driver.md" "supertubes/kafka-operator" >}}
 
 
 ## Prerequisites

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -10,6 +10,9 @@ The operator installs version 3.1.0 of Apache Kafka, and can run on Minikube v0.
 
 > The operator supports Kafka 2.6.2-3.1.x.
 
+{{< include "warning-ebs-csi-driver.md" "supertubes/kafka-operator" >}}
+
+
 ## Prerequisites
 
 - A Kubernetes cluster (minimum 6 vCPU and 10 GB RAM). You can create one using the [Banzai Cloud Pipeline platform](/products/pipeline/), or any other tool of your choice.

--- a/docs/warning-ebs-csi-driver.md
+++ b/docs/warning-ebs-csi-driver.md
@@ -1,0 +1,3 @@
+---
+---
+{{< warning >}}Both ZooKeeper clsuter and Kafka cluster need [persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to store data. Therefore, when installing the operator on Amazon EKS with Kuberentes version >= 1.23, you [must install the EBS CSI driver add-on](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) on your cluster. {{< /warning >}}

--- a/docs/warning-ebs-csi-driver.md
+++ b/docs/warning-ebs-csi-driver.md
@@ -1,3 +1,0 @@
----
----
-{{< warning >}}Both ZooKeeper clsuter and Kafka cluster need [persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to store data. Therefore, when installing the operator on Amazon EKS with Kuberentes version >= 1.23, you [must install the EBS CSI driver add-on](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) on your cluster. {{< /warning >}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add warning for installing koeprator in EKS with 1.23+

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Some users aren't ware of EBS CSI driver is needed for K8s 1.23+
