### PR TITLE
Fix branch name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Documentation for Koperator - the operator for managing Apache Kafka on Kubernet
 This repository contains the documentation for the [Koperator](https://github.com/banzaicloud/koperator).
 
 - The _master_ branch contains the public documentation of Koperator, published at https://banzaicloud.com/docs/supertubes/kafka-operator/
-- The _supertubes-integration_ branch contains the Koperator docs for Calisti. The different branches are needed because of the different release schedule of Koperator and Calisti, and the path/url differences between the public Koperator docs and Calisti. The Calisti docs is published at [https://docs.calisti.app/sdm/koperator/](https://docs.calisti.app/sdm/koperator/).
+- The _supertubes-rebranding_ branch contains the Koperator docs for Calisti. The different branches are needed because of the different release schedule of Koperator and Calisti, and the path/url differences between the public Koperator docs and Calisti. The Calisti docs is published at [https://docs.calisti.app/sdm/koperator/](https://docs.calisti.app/sdm/koperator/).


### PR DESCRIPTION
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

`supertubes-rebranding` is the actual name of that branch in this repo.
