### PR TITLE
Udapted zookeeper sample replica count

### DIFF
--- a/docs/create-zookeeper.sample
+++ b/docs/create-zookeeper.sample
@@ -5,7 +5,7 @@ metadata:
     name: zookeeper
     namespace: zookeeper
 spec:
-    replicas: 1
+    replicas: 3
     persistence:
         reclaimPolicy: Delete
 EOF


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
I updated the zookeeper replica count.

### Why?
This is to make it easier to discover connection issues earlier as more than one zookeeper pods may not come up if we have such an issue.


### Checklist

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
