### PR TITLE
Fix duplicate container port

### DIFF
--- a/docs/enable-ssl.sample
+++ b/docs/enable-ssl.sample
@@ -3,7 +3,7 @@ listenersConfig:
     - type: "ssl"
       name: "external"
       externalStartingPort: 19090
-      containerPort: 29092
+      containerPort: 9094
   internalListeners:
     - type: "ssl"
       name: "internal"


### PR DESCRIPTION
### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Current example uses the same container port for the external listener and one of the internal listener, which is not allowed

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Using current configuration would result in error in Koperator, example resulting error:
```
{"level":"error","ts":"2023-04-19T14:55:28.604Z","msg":"Reconciler error","controller":"KafkaCluster","controllerGroup":"kafka.banzaicloud.io","controllerKind":"KafkaCluster","KafkaCluster":{"name":"kafka","namespace":"kafka"},"namespace":"kafka","name":"kafka","reconcileID":"7683bd8b-9dfc-4d85-b4ee-6cfad00b4737","error":"creating resource failed: Service \"envoy-loadbalancer-external-kafka\" is invalid: spec.ports[3]: Duplicate value: core.ServicePort{Name:\"\", Protocol:\"TCP\", AppProtocol:(*string)(nil), Port:29092, TargetPort:intstr.IntOrString{Type:0, IntVal:0, StrVal:\"\"}, NodePort:0}","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:326\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234"}
```