### PR TITLE
Replace kafka-topics --zookeeper flags with --bootstrap-server flags due to Kafka 3.0.0 deprecation

### DIFF
--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -125,11 +125,23 @@ How to setup the environment for the Kafka Performance Test.
 
 1. Exec into this client and create the `perftest, perftest2, perftes3` topics.
 
+    For internal listeners exposed by a headless service (`KafkaCluster.spec.headlessServiceEnabled `set to `true`):
+
+    ```bash
+
+    kubectl exec -it kafka-test -n kafka bash
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-headless.kafka:29092 --topic perftest --create --replication-factor 3 --partitions 3
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-headless.kafka:29092 --topic perftest2 --create --replication-factor 3 --partitions 3
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-headless.kafka:29092 --topic perftest3 --create --replication-factor 3 --partitions 3
+    ```
+
+    For internal listeners exposed by a regular service (`KafkaCluster.spec.headlessServiceEnabled` set to `false`):
+
     ```bash
     kubectl exec -it kafka-test -n kafka bash
-    ./opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper-client.zookeeper:2181 --topic perftest --create --replication-factor 3 --partitions 3
-    ./opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper-client.zookeeper:2181 --topic perftest2 --create --replication-factor 3 --partitions 3
-    ./opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper-client.zookeeper:2181 --topic perftest3 --create --replication-factor 3 --partitions 3
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-all-broker.kafka:29092 --topic perftest --create --replication-factor 3 --partitions 3
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-all-broker.kafka:29092 --topic perftest2 --create --replication-factor 3 --partitions 3
+    ./opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-all-broker.kafka:29092 --topic perftest3 --create --replication-factor 3 --partitions 3
     ```
 
 Monitoring environment is automatically installed. To monitor the infrastructure we used the official Node Exporter dashboard available with id `1860`.

--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -125,7 +125,7 @@ How to setup the environment for the Kafka Performance Test.
 
 1. Exec into this client and create the `perftest, perftest2, perftes3` topics.
 
-    For internal listeners exposed by a headless service (`KafkaCluster.spec.headlessServiceEnabled `set to `true`):
+    For internal listeners exposed by a headless service (`KafkaCluster.spec.headlessServiceEnabled` is set to `true`):
 
     ```bash
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -22,8 +22,16 @@ Topic creation by default is enabled in Apache Kafka, but if it is configured ot
 
 - To create a sample topic from the CLI you can run the following:
 
+    For internal listeners exposed by a headless service (`KafkaCluster.spec.headlessServiceEnabled `set to `true`):
+
     ```bash
-    kubectl -n kafka run kafka-topics -it --image=ghcr.io/banzaicloud/kafka:2.13-3.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper-client.zookeeper:2181 --topic my-topic --create --partitions 1 --replication-factor 1
+    kubectl -n kafka run kafka-topics -it --image=ghcr.io/banzaicloud/kafka:2.13-3.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-headless.kafka:29092 --topic my-topic --create --partitions 1 --replication-factor 1
+    ```
+
+    For internal listeners exposed by a regular service (`KafkaCluster.spec.headlessServiceEnabled` set to `false`):
+
+    ```bash
+    kubectl -n kafka run kafka-topics -it --image=ghcr.io/banzaicloud/kafka:2.13-3.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka-all-broker.kafka:29092 --topic my-topic --create --partitions 1 --replication-factor 1
     ```
 
 After you have created a topic, produce and consume some messages:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #88 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Replacing `--zookeeper zookeeper-client.zookeeper:2181` kafka-topics command references with `--bootstrap-server kafka-all-broker.kafka:29092`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

From Kafka [3.0.0 the `--zookeeper ${ZOOKEEPER_CLIENT_SERVICE_HOST_PORT}` flag was deprecated in favor of the `--bootstrap-server ${KAFKA_ALL_BROKER_SERVICE_HOST_PORT}` flag](https://kafka.apache.org/documentation/#upgrade_300_notable).

> The --zookeeper option was removed from the kafka-topics and kafka-reassign-partitions command line tools. Please use --bootstrap-server instead.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
