### PR TITLE
Fixed GH version links in install docs

### DIFF
--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -607,7 +607,7 @@ This method uses a command-line tool of the commercial [Banzai Cloud Supertubes]
         ```bash
         kubectl create \
         -n kafka \
-        -f https://raw.githubusercontent.com/banzaicloud/koperator/{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/simplekafkacluster.yaml
+        -f https://raw.githubusercontent.com/banzaicloud/koperator/v{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/simplekafkacluster.yaml
         ```
 
     - To create a sample Kafka cluster that allows TLS-encrypted client connections, run the following command. For details on the configuration parameters related to SSL, see {{% xref "/docs/supertubes/kafka-operator/ssl.md#enable-ssl" %}}.
@@ -615,7 +615,7 @@ This method uses a command-line tool of the commercial [Banzai Cloud Supertubes]
         ```bash
         kubectl create \
         -n kafka \
-        -f https://raw.githubusercontent.com/banzaicloud/koperator/{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/simplekafkacluster_ssl.yaml
+        -f https://raw.githubusercontent.com/banzaicloud/koperator/v{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/simplekafkacluster_ssl.yaml
         ```
 
     Expected output:
@@ -676,7 +676,7 @@ This method uses a command-line tool of the commercial [Banzai Cloud Supertubes]
     ```bash
     kubectl create \
     -n kafka \
-    -f https://raw.githubusercontent.com/banzaicloud/koperator/{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/kafkacluster-prometheus.yaml
+    -f https://raw.githubusercontent.com/banzaicloud/koperator/v{{< param "versionnumbers-sdm.koperatorCurrentversion" >}}/config/samples/kafkacluster-prometheus.yaml
     ```
 
     Expected output:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed GH version links in install docs.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

They were broken. See at https://banzaicloud.com/docs/supertubes/kafka-operator/install-kafka-operator/ with the last `kubectl create` command the Prometheus instance manifest link.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
