### PR TITLE
Updated default zookeper cluster naming

### DIFF
--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -62,7 +62,7 @@ How to setup the environment for the Kafka Performance Test.
     apiVersion: zookeeper.pravega.io/v1beta1
     kind: ZookeeperCluster
     metadata:
-      name: zookeeper
+      name: zookeeper-server
       namespace: zookeeper
     spec:
       replicas: 3

--- a/docs/create-zookeeper.sample
+++ b/docs/create-zookeeper.sample
@@ -2,7 +2,7 @@ kubectl create -f - <<EOF
 apiVersion: zookeeper.pravega.io/v1beta1
 kind: ZookeeperCluster
 metadata:
-    name: zookeeper
+    name: zookeeper-server
     namespace: zookeeper
 spec:
     replicas: 3

--- a/docs/delete-kafka-operator.md
+++ b/docs/delete-kafka-operator.md
@@ -105,13 +105,13 @@ In case you want to delete the {{< kafka-operator >}} from your cluster, note th
 1. Delete Zookeeper CR.
 
     ```
-    kubectl delete zookeeperclusters -n zookeeper zookeeper
+    kubectl delete zookeeperclusters -n zookeeper zookeeper-server
     ```
 
     Expected output:
 
     ```
-    zookeeperclusters.zookeeper.pravega.io/zookeeper deleted
+    zookeeperclusters.zookeeper.pravega.io/zookeeper-server deleted
     ```
 
     Wait for the Zookeeper resources (Deployment, PersistentVolumeClaims, Configmaps, etc) to be removed.

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -303,7 +303,7 @@ This method uses a command-line tool of the commercial [Banzai Cloud Supertubes]
 
     ```bash
     NAME                                  READY   STATUS    RESTARTS   AGE
-    zookeeper-0                           1/1     Running   0          27m
+    zookeeper-server-0                    1/1     Running   0          27m
     zookeeper-operator-54444dbd9d-2tccj   1/1     Running   0          28m
     ```
 

--- a/docs/troubleshooting/_index.md
+++ b/docs/troubleshooting/_index.md
@@ -129,7 +129,7 @@ spec:
   rollingUpgradeConfig:
     failureThreshold: 1
   zkAddresses:
-  - zookeeper-client.zookeeper:2181
+  - zookeeper-server-client.zookeeper:2181
 status:
   alertCount: 0
   brokersState:
@@ -200,6 +200,6 @@ Before asking for help, prepare the following information to make troubleshootin
 - Kafka broker logs
 - {{< kafka-operator >}} configuration
 - Kafka cluster configuration (**kubectl describe KafkaCluster kafka -n kafka**)
-- ZooKeeper configuration (**kubectl describe ZookeeperCluster zookeeper -n zookeeper**)
+- ZooKeeper configuration (**kubectl describe ZookeeperCluster zookeeper-server -n zookeeper**)
 - ZooKeeper logs (**kubectl logs zookeeper-operator-5c9b597bcc-vkdz9 -n zookeeper**)
 Do not forget to remove any sensitive information (for example, passwords and private keys) before sharing.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Updated naming for the default zookeeper cluster from `zookeeper` to `zookeeper-server`

### Why?
To be consistent with Calisti.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
